### PR TITLE
External Metadata Support

### DIFF
--- a/browsertrix/main.py
+++ b/browsertrix/main.py
@@ -229,7 +229,7 @@ while True:
             data[aid] = {"last_check": 0, "crawls": []}
 
         new_last_check = data[aid]["last_check"]
-        new_crawls = []
+        new_crawls = data[aid]['crawls']
 
         i = 1
         while True:


### PR DESCRIPTION
- Corrected filter for empty finished date/time
- pages/pages.jsonl sometimes missing, corrected for this
- Save asset in zip as a sha(assent).wacz
- Read external metadata from file from crawler and include it in the content meta data
- If external file exists, write sha256 ID down