### PR TITLE
Browsertrix queue support

### DIFF
--- a/browsertrix/main.py
+++ b/browsertrix/main.py
@@ -641,7 +641,6 @@ while True:
         break
 
     queuelist = []
-    running_count = 0
     for archive in r.json()["archives"]:
         while True:
             aid = archive["id"]


### PR DESCRIPTION
Browsertrix currently does NOT queue up requests when using API

Support added to QUEUE crawls and have preprocessor start them when available to do so.

Crawl Name is prefixed by `_Q_` `_R_` or `_D_`

`_Q_` in queue, preprocessor will trigger crawl when required
`_R_` Updated to this when queue script starts a crawl
`_D_` Updated to this when preprocessor find `_R_` if finished